### PR TITLE
Fix bug #5

### DIFF
--- a/lib/xml-formatter.coffee
+++ b/lib/xml-formatter.coffee
@@ -32,7 +32,7 @@ module.exports =
             indent = 0
           else if node.match(/^<\/\w/)
             pad -= 1  unless pad is 0
-          else if node.match(/^<\w[^>]*[^\/]>.*$/)
+          else if node.match(/^<\w/) and !node.match(/\/>/)
             indent = 1
           else
             indent = 0


### PR DESCRIPTION
Properly skip empty tags (for example "`<empty/>`") while supporting tags with names of length 1 (for example "`<a>`"). This fixes [bug #5](https://github.com/neyestrabelli/xml-formatter/issues/5).
