### PR TITLE
Fixed bug #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # xml-formatter package
 
-Simple XML Formatter, hit `CMD-SHIFT-X`.
+Simple XML Formatter, hit `CMD-SHIFT-X` on a Mac or `SHIFT-CTRL-X` on Windows or
+Linux.
 
 ## Preview
 
@@ -18,4 +19,4 @@ Indent Character
 
 Spaces Indent
 
-- Default 2 
+- Default 2

--- a/keymaps/xml-formatter.cson
+++ b/keymaps/xml-formatter.cson
@@ -7,5 +7,8 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'.platform-darwin .editor':
   'cmd-shift-x': 'xml-formatter:indent'
+
+'.platform-win32 .editor, .platform-linux .editor':
+  'shift-ctrl-x': 'xml-formatter:indent'


### PR DESCRIPTION
The keymap will conditionally choose the indent keymap based on the OS.  Windows and Linux will use shift-ctrl-x while Mac will still use cmd-shift-x.
