### PR TITLE
Replace deprecated .editor class

### DIFF
--- a/keymaps/xml-formatter.cson
+++ b/keymaps/xml-formatter.cson
@@ -7,8 +7,8 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin .editor':
+'body.platform-darwin atom-text-editor':
   'cmd-shift-x': 'xml-formatter:indent'
 
-'.platform-win32 .editor, .platform-linux .editor':
+'body.platform-win32 atom-text-editor, body.platform-linux atom-text-editor':
   'shift-ctrl-x': 'xml-formatter:indent'


### PR DESCRIPTION
.editor class is deprecated in favor of `atom-text-editor` tag