### PR TITLE
Show context menu only in text editor

### DIFF
--- a/menus/xml-formatter.cson
+++ b/menus/xml-formatter.cson
@@ -1,7 +1,7 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  'atom-workspace': [
-    { 'label': 'Enable xml-formatter', 'command': 'xml-formatter:indent' }
+  'atom-text-editor': [
+    { 'label': 'Format XML', 'command': 'xml-formatter:indent' }
   ]
 
 'menu': [


### PR DESCRIPTION
Resolve #17. Show XML formatter context menu options only in text editor, not in the whole application. Changed menu label from 'Enable xml-formatter' to 'Format XML' to better represent the function of the option.